### PR TITLE
Ignore base .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel


### PR DESCRIPTION
## Summary
- add the base `.env` file to the gitignore so environment secrets are never committed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98ad72454832c8edd0bf8351d5706