### PR TITLE
Fix page scroll to exclude header and footer

### DIFF
--- a/src/app/footer/footer.tsx
+++ b/src/app/footer/footer.tsx
@@ -6,7 +6,7 @@ import DisplayContactInfoModal from "../contact_info/contact-info";
 
 export function Footer() {
   return (
-    <div className="fixed inset-x-0 bottom-0 m-auto bg-white dark:bg-slate-900 shadow-lg">
+    <div className="fixed inset-x-0 bottom-0 z-50 m-auto bg-white shadow-lg dark:bg-slate-900">
       <ListPages />
     </div>
   );

--- a/src/app/header/header.tsx
+++ b/src/app/header/header.tsx
@@ -2,7 +2,7 @@ import { ThemeSwitchHandler } from "../theme_switch/theme_switch";
 
 export function Header() {
   return (
-    <div className="sticky top-0 left-0 right-0 min-w-full bg-neutral-50 dark:bg-gray-900 shadow-md">
+    <div className="fixed inset-x-0 top-0 z-50 min-w-full bg-neutral-50 shadow-md dark:bg-gray-900">
       <div className="h-32 py-8 grid grid-cols-1">
         <div className="flex justify-center">
           <Title />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,11 +21,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${inter.className} flex min-h-screen flex-col overflow-hidden`}
-      >
+      <body className={`${inter.className} flex min-h-screen flex-col`}>
         <Header />
-        <main className="flex-1 overflow-y-auto pb-24 pt-32">
+        <main className="flex-1 pb-24 pt-32">
           <Providers>{children}</Providers>
         </main>
         <Footer />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,11 +21,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body
+        className={`${inter.className} flex min-h-screen flex-col overflow-hidden`}
+      >
         <Header />
-        <main>
+        <main className="flex-1 overflow-y-auto pb-24 pt-32">
           <Providers>{children}</Providers>
-        </main> 
+        </main>
         <Footer />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- prevent the document body from scrolling so the header and footer stay fixed
- allow the main content area to scroll independently with padding that avoids overlap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d991213bdc832ca088c875c3ac3465