### PR TITLE
Revamp about-me page layout

### DIFF
--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -9,26 +9,26 @@ export default function Page() {
 
 function CenterSection() {
   return (
-    <div className="relative isolate min-h-[calc(100vh-6rem)] overflow-hidden bg-gradient-to-br from-sky-50 via-purple-50 to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900">
+    <div className="relative isolate min-h-[calc(100vh-6rem)] overflow-hidden bg-gradient-to-br from-amber-50 via-orange-50 to-amber-100 dark:from-stone-950 dark:via-zinc-950 dark:to-stone-900">
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center blur-3xl">
-        <div className="h-48 w-[36rem] bg-gradient-to-r from-sky-300/60 via-indigo-400/60 to-fuchsia-400/60 opacity-40 dark:from-sky-500/40 dark:via-indigo-500/40 dark:to-fuchsia-500/40" />
+        <div className="h-48 w-[36rem] bg-gradient-to-r from-amber-300/60 via-orange-300/60 to-amber-200/60 opacity-40 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
       </div>
 
       <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16 sm:px-10 lg:px-16">
-        <section className="grid gap-10 rounded-3xl border border-slate-200/70 bg-white/80 p-10 shadow-2xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-slate-900/60 dark:shadow-slate-950/40 max-lg:p-8 lg:grid-cols-[1.1fr,0.9fr]">
-          <div className="flex flex-col gap-6 text-slate-900 dark:text-slate-100">
-            <div className="flex flex-wrap items-center gap-3 text-slate-600 dark:text-slate-300">
-              <span className="rounded-full bg-sky-100 px-3 py-1 text-sm font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-200">
+        <section className="grid gap-10 rounded-3xl border border-amber-200/60 bg-amber-50/80 p-10 shadow-2xl backdrop-blur-xl transition-colors dark:border-stone-700/60 dark:bg-stone-900/70 dark:shadow-black/30 max-lg:p-8 lg:grid-cols-[1.1fr,0.9fr]">
+          <div className="flex flex-col gap-6 text-stone-900 dark:text-amber-100">
+            <div className="flex flex-wrap items-center gap-3 text-stone-600 dark:text-amber-200/80">
+              <span className="rounded-full bg-amber-200 px-3 py-1 text-sm font-semibold text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
                 Full-Stack Engineer
               </span>
-              <span className="rounded-full bg-purple-100 px-3 py-1 text-sm font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
+              <span className="rounded-full bg-orange-200 px-3 py-1 text-sm font-semibold text-orange-800 dark:bg-orange-900/50 dark:text-orange-200">
                 Maker &amp; Music Enthusiast
               </span>
             </div>
             <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
               Programmer, tinkerer, relentless explorer of ideas.
             </h1>
-            <p className="text-lg leading-relaxed text-slate-700 dark:text-slate-300">
+            <p className="text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
               I&#39;m a full-stack engineer who finds joy in building thoughtful
               experiences and experimenting with new technologies. When I&#39;m
               not writing code you can probably find me digging through obscure
@@ -39,25 +39,25 @@ function CenterSection() {
               <InfoCard
                 title="Crafting &amp; Shipping"
                 description="From interactive web apps to physical prototypes, I love taking an idea from sketch to reality."
-                accent="from-sky-400/40 via-sky-300/40 to-transparent"
+                accent="from-amber-400/40 via-orange-300/40 to-transparent"
                 emoji="🛠️"
               />
               <InfoCard
                 title="Always Learning"
                 description="Recent dives include edge runtimes, creative coding, and modular synthesis—there&#39;s always a new rabbit hole."
-                accent="from-fuchsia-400/40 via-purple-300/40 to-transparent"
+                accent="from-amber-500/35 via-yellow-200/35 to-transparent"
                 emoji="🧠"
               />
             </div>
           </div>
           <div className="grid gap-8 lg:pl-8">
             <div className="relative mx-auto flex h-full w-full max-w-sm items-center justify-center">
-              <div className="absolute -inset-6 rounded-[36px] bg-gradient-to-br from-sky-200 via-indigo-200 to-fuchsia-200 opacity-70 blur-2xl dark:from-sky-500/30 dark:via-indigo-500/30 dark:to-fuchsia-500/30" />
-              <div className="relative rounded-[32px] border border-white/40 bg-white/80 p-5 shadow-xl backdrop-blur-lg dark:border-slate-700/60 dark:bg-slate-950/80">
+              <div className="absolute -inset-6 rounded-[36px] bg-gradient-to-br from-amber-200 via-orange-200 to-amber-100 opacity-70 blur-2xl dark:from-amber-500/20 dark:via-orange-500/20 dark:to-amber-500/20" />
+              <div className="relative rounded-[32px] border border-white/40 bg-amber-50/80 p-5 shadow-xl backdrop-blur-lg dark:border-stone-700/60 dark:bg-stone-950/80">
                 <SelfImage />
               </div>
             </div>
-            <ul className="grid gap-3 text-sm text-slate-700 dark:text-slate-300">
+            <ul className="grid gap-3 text-sm text-stone-700 dark:text-amber-100/80">
               <QuickFact label="Based in" value="Austin, TX" />
               <QuickFact label="Currently exploring" value="AI-assisted tooling &amp; creative coding" />
               <QuickFact label="Favorite mediums" value="TypeScript, React, analog synths" />
@@ -66,9 +66,9 @@ function CenterSection() {
           </div>
         </section>
 
-        <section className="grid gap-8 rounded-3xl border border-slate-200/70 bg-white/70 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-slate-900/60 max-lg:p-8 lg:grid-cols-[1.15fr,0.85fr]">
-          <div className="space-y-6 text-slate-700 dark:text-slate-300">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        <section className="grid gap-8 rounded-3xl border border-amber-200/60 bg-amber-100/70 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-stone-700/60 dark:bg-stone-900/70 max-lg:p-8 lg:grid-cols-[1.15fr,0.85fr]">
+          <div className="space-y-6 text-stone-700 dark:text-amber-100/80">
+            <h2 className="text-2xl font-semibold text-stone-900 dark:text-amber-100">
               What drives me
             </h2>
             <p className="text-lg leading-relaxed">
@@ -89,7 +89,7 @@ function CenterSection() {
           </div>
 
           <div className="flex flex-col gap-6">
-            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            <h3 className="text-xl font-semibold text-stone-900 dark:text-amber-100">
               Recent highlights
             </h3>
             <div className="grid gap-4">
@@ -109,8 +109,8 @@ function CenterSection() {
           </div>
         </section>
 
-        <section className="grid gap-8 rounded-3xl border border-slate-200/70 bg-gradient-to-br from-sky-100 via-white to-purple-100 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-gradient-to-br dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 max-lg:p-8 lg:grid-cols-[0.9fr,1.1fr]">
-          <div className="space-y-6 text-slate-800 dark:text-slate-200">
+        <section className="grid gap-8 rounded-3xl border border-amber-200/60 bg-gradient-to-br from-amber-100 via-amber-50 to-orange-100 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-stone-700/60 dark:bg-gradient-to-br dark:from-stone-950 dark:via-zinc-950 dark:to-stone-900 max-lg:p-8 lg:grid-cols-[0.9fr,1.1fr]">
+          <div className="space-y-6 text-stone-800 dark:text-amber-100">
             <h2 className="text-2xl font-semibold">Connect with me</h2>
             <p>
               If you&#39;d like to see more of my work or collaborate on an
@@ -118,7 +118,7 @@ function CenterSection() {
               LinkedIn, or email—links are in the contact section. I&#39;m
               always open to conversations.
             </p>
-            <p className="text-sm text-slate-600 dark:text-slate-400">
+            <p className="text-sm text-stone-600 dark:text-amber-200/70">
               Bonus: mention your favorite synth, playlist, or side project
               when you say hi.
             </p>
@@ -160,16 +160,16 @@ type InfoCardProps = {
 
 function InfoCard({ title, description, emoji, accent }: InfoCardProps) {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-slate-200/60 bg-white/70 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/60 dark:bg-slate-950/60">
+    <div className="relative overflow-hidden rounded-2xl border border-amber-200/60 bg-amber-50/80 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-stone-700/60 dark:bg-stone-950/70">
       <div
         className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${accent}`}
       />
-      <div className="relative flex flex-col gap-2 text-slate-800 dark:text-slate-100">
+      <div className="relative flex flex-col gap-2 text-stone-800 dark:text-amber-100">
         <span className="text-2xl" aria-hidden>
           {emoji}
         </span>
         <h3 className="text-lg font-semibold">{title}</h3>
-        <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+        <p className="text-sm leading-relaxed text-stone-600 dark:text-amber-200/80">
           {description}
         </p>
       </div>
@@ -184,13 +184,13 @@ type QuickFactProps = {
 
 function QuickFact({ label, value }: QuickFactProps) {
   return (
-    <li className="flex items-start gap-3 rounded-2xl border border-slate-200/60 bg-white/70 p-4 text-sm shadow-md transition-colors dark:border-slate-700/60 dark:bg-slate-950/60">
-      <span className="mt-0.5 h-2 w-2 rounded-full bg-gradient-to-br from-sky-400 to-fuchsia-500 dark:from-sky-500 dark:to-fuchsia-500" />
+    <li className="flex items-start gap-3 rounded-2xl border border-amber-200/60 bg-amber-50/80 p-4 text-sm shadow-md transition-colors dark:border-stone-700/60 dark:bg-stone-950/70">
+      <span className="mt-0.5 h-2 w-2 rounded-full bg-gradient-to-br from-amber-400 to-orange-500 dark:from-amber-500 dark:to-orange-500" />
       <div>
-        <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <p className="text-xs uppercase tracking-wide text-stone-500 dark:text-amber-200/70">
           {label}
         </p>
-        <p className="text-base font-medium text-slate-800 dark:text-slate-100">
+        <p className="text-base font-medium text-stone-800 dark:text-amber-100">
           {value}
         </p>
       </div>
@@ -205,11 +205,11 @@ type HighlightItemProps = {
 
 function HighlightItem({ title, description }: HighlightItemProps) {
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white/70 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/60 dark:bg-slate-950/60">
-      <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+    <div className="rounded-2xl border border-amber-200/60 bg-amber-50/80 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-stone-700/60 dark:bg-stone-950/70">
+      <h4 className="text-lg font-semibold text-stone-900 dark:text-amber-100">
         {title}
       </h4>
-      <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+      <p className="mt-2 text-sm leading-relaxed text-stone-600 dark:text-amber-200/80">
         {description}
       </p>
     </div>
@@ -225,18 +225,18 @@ type ConnectionCardProps = {
 function ConnectionCard({ title, description, href }: ConnectionCardProps) {
   return (
     <a
-      className="group flex flex-col gap-2 rounded-2xl border border-slate-200/60 bg-white/80 p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 dark:border-slate-700/60 dark:bg-slate-950/70"
+      className="group flex flex-col gap-2 rounded-2xl border border-amber-200/60 bg-amber-50/80 p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 dark:border-stone-700/60 dark:bg-stone-950/70"
       href={href}
     >
       <div className="flex items-center justify-between">
-        <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+        <h4 className="text-lg font-semibold text-stone-900 dark:text-amber-100">
           {title}
         </h4>
-        <span className="text-slate-400 transition-transform group-hover:translate-x-1 dark:text-slate-500">
+        <span className="text-amber-500 transition-transform group-hover:translate-x-1 dark:text-amber-300">
           →
         </span>
       </div>
-      <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+      <p className="text-sm leading-relaxed text-stone-600 dark:text-amber-200/80">
         {description}
       </p>
     </a>

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,18 +1,4 @@
-"use client";
-import Image from "next/image";
-import dynamic from "next/dynamic";
-import React, { useState, useEffect, useRef } from "react";
-
-const DotLottie = dynamic(
-  () =>
-    import("@lottiefiles/dotlottie-react").then((mod) => mod.DotLottieReact),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="h-full w-full animate-pulse rounded-full bg-gradient-to-br from-amber-200 via-orange-200 to-amber-100 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
-    ),
-  }
-) as typeof import("@lottiefiles/dotlottie-react").DotLottieReact;
+import SelfImage from "./self-image";
 
 export default function Page() {
   return <CenterSection />;
@@ -251,70 +237,5 @@ function ConnectionCard({ title, description, href }: ConnectionCardProps) {
         {description}
       </p>
     </a>
-  );
-}
-
-function SelfImage() {
-  const [hasLoaded, setHasLoaded] = useState(false);
-  const [hasMinDurationElapsed, setHasMinDurationElapsed] = useState(false);
-  const minDuration = 300; // Minimum duration for the loading animation in milliseconds
-  const imageRef = useRef<HTMLImageElement | null>(null);
-
-  useEffect(() => {
-    if (imageRef.current && imageRef.current.complete) {
-      // Skip the animation entirely if the image is already in the browser cache
-      setHasLoaded(true);
-      setHasMinDurationElapsed(true);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      setHasMinDurationElapsed(true);
-    }, minDuration);
-
-    return () => clearTimeout(timer);
-  }, [minDuration]);
-
-  const handleImageLoad = () => {
-    setHasLoaded(true);
-  };
-
-  const isLoading = !(hasLoaded && hasMinDurationElapsed);
-
-  return (
-    <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center rounded-[50%]">
-      <DotLottie
-        src="/image-load.lottie"
-        autoplay
-        loop
-        style={{
-          width: "100%",
-          height: "100%",
-          opacity: isLoading ? 1 : 0,
-          visibility: isLoading ? "visible" : "hidden",
-          transition: "opacity 0.5s ease-out, visibility 0.5s ease-out",
-          position: "absolute",
-          inset: 0,
-          pointerEvents: "none",
-        }}
-      />
-      <Image
-        ref={imageRef}
-        src="/me.jpg"
-        alt="A picture of me"
-        sizes="100vw"
-        width={384}
-        height={384}
-        placeholder="empty"
-        style={{
-          width: "100%",
-          height: "100%",
-          opacity: isLoading ? 0 : 1,
-          transition: "opacity 1s ease-in-out",
-        }}
-        className="rounded-[50%] shadow-md"
-        onLoad={handleImageLoad}
-      />
-    </div>
   );
 }

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,7 +1,18 @@
 "use client";
 import Image from "next/image";
+import dynamic from "next/dynamic";
 import React, { useState, useEffect, useRef } from "react";
-import { DotLottieReact } from "@lottiefiles/dotlottie-react";
+
+const DotLottie = dynamic(
+  () =>
+    import("@lottiefiles/dotlottie-react").then((mod) => mod.DotLottieReact),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full animate-pulse rounded-full bg-gradient-to-br from-amber-200 via-orange-200 to-amber-100 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
+    ),
+  }
+) as typeof import("@lottiefiles/dotlottie-react").DotLottieReact;
 
 export default function Page() {
   return <CenterSection />;
@@ -264,7 +275,7 @@ function SelfImage() {
     return () => clearTimeout(timer);
   }, [minDuration]);
 
-  const handleImageLoadComplete = () => {
+  const handleImageLoad = () => {
     setHasLoaded(true);
   };
 
@@ -272,7 +283,7 @@ function SelfImage() {
 
   return (
     <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center rounded-[50%]">
-      <DotLottieReact
+      <DotLottie
         src="/image-load.lottie"
         autoplay
         loop
@@ -302,7 +313,7 @@ function SelfImage() {
           transition: "opacity 1s ease-in-out",
         }}
         className="rounded-[50%] shadow-md"
-        onLoadingComplete={handleImageLoadComplete}
+        onLoad={handleImageLoad}
       />
     </div>
   );

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -9,62 +9,237 @@ export default function Page() {
 
 function CenterSection() {
   return (
-    <div>
-      <div className="flex justify-center py-[8%]">
-        <div className="min-w-[192px] min-h-[192px] max-h-[384px] max-w-[384px] py-5 max-[384px]:hidden">
-          <SelfImage />
-        </div>
-        <div className="px-5 flex flex-col justify-center justify-items-center dark:text-slate-300">
-          <div className="text-5xl max-[384px]:text-xl max-[768px]:text-2xl md:text-3xl lg:text-4xl flex justify-start">
-            <h1 className="font-semibold">Programmer, tinkerer, hobbyist. </h1>
-          </div>
-          <div className="py-6 flex justify-start max-w-[700px]">
-            <div className="text-md max-[384px]:text-xs max-[768px]:text-sm md:text-md lg:text-md ">
-              <h3 className="font-semibold text-xl max-[384px]:text-xs max-[768px]:text-sm md:text-md lg:text-md">
-                Welcome to my corner of the web!
-              </h3>
-              <p>
-                I&#39;m a full-stack software engineer with a knack for
-                exploring new tech. Whether it&#39;s coding, digging into
-                obscure electronic music, or picking up a fresh hobby, I&#39;m
-                always finding something new to dive into.
-              </p>
-              <br />
-              <p>
-                I enjoy building and experimenting—whether it&#39;s hardware,
-                software, or a side project that piques my interest. I&#39;m
-                constantly learning and expanding my skill set, from frameworks
-                to music production, always focused on creating something
-                meaningful and well-crafted.
-              </p>
-              <br />
-              <h3 className="font-semibold text-xl max-[384px]:text-xs max-[768px]:text-sm md:text-md lg:text-md ">
-                Plans for this site
-              </h3>
-              <p>
-                This site is still a work-in-progress. I&#39;m working on a
-                &#39;Projects&#39; section where you&#39;ll find a selection of
-                recent work, projects, and maybe a few experimental ideas.
-              </p>
-              <br />
-              <p>
-                Content will continue to evolve here, so check back for updates.
-              </p>
-              <br />
-              <h3 className="font-semibold text-xl max-[384px]:text-xs max-[768px]:text-sm md:text-md lg:text-md ">
-                Connect with Me
-              </h3>
-              <p>
-                If you&#39;d like to see more of my work or connect, you can
-                reach out via Github, LinkedIn, or email, listed below in the
-                &#39;Contact Info&#39; section. I&#39;m always open to
-                conversations.
-              </p>
+    <div className="relative isolate min-h-[calc(100vh-6rem)] overflow-hidden bg-gradient-to-br from-sky-50 via-purple-50 to-slate-100 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center blur-3xl">
+        <div className="h-48 w-[36rem] bg-gradient-to-r from-sky-300/60 via-indigo-400/60 to-fuchsia-400/60 opacity-40 dark:from-sky-500/40 dark:via-indigo-500/40 dark:to-fuchsia-500/40" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16 sm:px-10 lg:px-16">
+        <section className="grid gap-10 rounded-3xl border border-slate-200/70 bg-white/80 p-10 shadow-2xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-slate-900/60 dark:shadow-slate-950/40 max-lg:p-8 lg:grid-cols-[1.1fr,0.9fr]">
+          <div className="flex flex-col gap-6 text-slate-900 dark:text-slate-100">
+            <div className="flex flex-wrap items-center gap-3 text-slate-600 dark:text-slate-300">
+              <span className="rounded-full bg-sky-100 px-3 py-1 text-sm font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-200">
+                Full-Stack Engineer
+              </span>
+              <span className="rounded-full bg-purple-100 px-3 py-1 text-sm font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
+                Maker &amp; Music Enthusiast
+              </span>
+            </div>
+            <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
+              Programmer, tinkerer, relentless explorer of ideas.
+            </h1>
+            <p className="text-lg leading-relaxed text-slate-700 dark:text-slate-300">
+              I&#39;m a full-stack engineer who finds joy in building thoughtful
+              experiences and experimenting with new technologies. When I&#39;m
+              not writing code you can probably find me digging through obscure
+              electronic records, assembling hardware, or chasing down a new
+              hobby just to see how it works.
+            </p>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <InfoCard
+                title="Crafting &amp; Shipping"
+                description="From interactive web apps to physical prototypes, I love taking an idea from sketch to reality."
+                accent="from-sky-400/40 via-sky-300/40 to-transparent"
+                emoji="🛠️"
+              />
+              <InfoCard
+                title="Always Learning"
+                description="Recent dives include edge runtimes, creative coding, and modular synthesis—there&#39;s always a new rabbit hole."
+                accent="from-fuchsia-400/40 via-purple-300/40 to-transparent"
+                emoji="🧠"
+              />
             </div>
           </div>
-        </div>
+          <div className="grid gap-8 lg:pl-8">
+            <div className="relative mx-auto flex h-full w-full max-w-sm items-center justify-center">
+              <div className="absolute -inset-6 rounded-[36px] bg-gradient-to-br from-sky-200 via-indigo-200 to-fuchsia-200 opacity-70 blur-2xl dark:from-sky-500/30 dark:via-indigo-500/30 dark:to-fuchsia-500/30" />
+              <div className="relative rounded-[32px] border border-white/40 bg-white/80 p-5 shadow-xl backdrop-blur-lg dark:border-slate-700/60 dark:bg-slate-950/80">
+                <SelfImage />
+              </div>
+            </div>
+            <ul className="grid gap-3 text-sm text-slate-700 dark:text-slate-300">
+              <QuickFact label="Based in" value="Austin, TX" />
+              <QuickFact label="Currently exploring" value="AI-assisted tooling &amp; creative coding" />
+              <QuickFact label="Favorite mediums" value="TypeScript, React, analog synths" />
+              <QuickFact label="What I&#39;m building next" value="An experimental projects showcase" />
+            </ul>
+          </div>
+        </section>
+
+        <section className="grid gap-8 rounded-3xl border border-slate-200/70 bg-white/70 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-slate-900/60 max-lg:p-8 lg:grid-cols-[1.15fr,0.85fr]">
+          <div className="space-y-6 text-slate-700 dark:text-slate-300">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              What drives me
+            </h2>
+            <p className="text-lg leading-relaxed">
+              I enjoy building and experimenting—whether it&#39;s hardware,
+              software, or a side project that piques my interest. I&#39;m
+              constantly learning and expanding my skill set, always focused on
+              creating something meaningful and well-crafted.
+            </p>
+            <p className="leading-relaxed">
+              This site is still a work in progress. I&#39;m assembling a
+              showcase that blends personal experiments with production-ready
+              work, along with behind-the-scenes write-ups and process notes.
+            </p>
+            <p className="leading-relaxed">
+              Content will continue to evolve here, so check back for updates
+              as new projects, articles, and collaborations roll out.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-6">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              Recent highlights
+            </h3>
+            <div className="grid gap-4">
+              <HighlightItem
+                title="Hands-on with edge runtimes"
+                description="Deploying real-time features with minimal latency using Next.js App Router."
+              />
+              <HighlightItem
+                title="Designing creative coding sketches"
+                description="Experimenting with shader-based visuals and generative art installations."
+              />
+              <HighlightItem
+                title="Building a modular synth rig"
+                description="Combining code, hardware, and music theory into a tactile sound playground."
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-8 rounded-3xl border border-slate-200/70 bg-gradient-to-br from-sky-100 via-white to-purple-100 p-10 shadow-xl backdrop-blur-xl transition-colors dark:border-slate-700/60 dark:bg-gradient-to-br dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 max-lg:p-8 lg:grid-cols-[0.9fr,1.1fr]">
+          <div className="space-y-6 text-slate-800 dark:text-slate-200">
+            <h2 className="text-2xl font-semibold">Connect with me</h2>
+            <p>
+              If you&#39;d like to see more of my work or collaborate on an
+              idea, I&#39;d love to chat. You can reach out via GitHub,
+              LinkedIn, or email—links are in the contact section. I&#39;m
+              always open to conversations.
+            </p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Bonus: mention your favorite synth, playlist, or side project
+              when you say hi.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <ConnectionCard
+              title="Github"
+              description="Code, experiments, and open-source contributions."
+              href="https://github.com"
+            />
+            <ConnectionCard
+              title="LinkedIn"
+              description="Work history, collaboration ideas, and professional updates."
+              href="https://www.linkedin.com"
+            />
+            <ConnectionCard
+              title="Email"
+              description="Drop me a line for projects, jam sessions, or just to say hi."
+              href="mailto:hello@example.com"
+            />
+            <ConnectionCard
+              title="Now page"
+              description="A living snapshot of what I&#39;m learning and building."
+              href="#"
+            />
+          </div>
+        </section>
       </div>
     </div>
+  );
+}
+
+type InfoCardProps = {
+  title: string;
+  description: string;
+  emoji: string;
+  accent: string;
+};
+
+function InfoCard({ title, description, emoji, accent }: InfoCardProps) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-slate-200/60 bg-white/70 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/60 dark:bg-slate-950/60">
+      <div
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${accent}`}
+      />
+      <div className="relative flex flex-col gap-2 text-slate-800 dark:text-slate-100">
+        <span className="text-2xl" aria-hidden>
+          {emoji}
+        </span>
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type QuickFactProps = {
+  label: string;
+  value: string;
+};
+
+function QuickFact({ label, value }: QuickFactProps) {
+  return (
+    <li className="flex items-start gap-3 rounded-2xl border border-slate-200/60 bg-white/70 p-4 text-sm shadow-md transition-colors dark:border-slate-700/60 dark:bg-slate-950/60">
+      <span className="mt-0.5 h-2 w-2 rounded-full bg-gradient-to-br from-sky-400 to-fuchsia-500 dark:from-sky-500 dark:to-fuchsia-500" />
+      <div>
+        <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {label}
+        </p>
+        <p className="text-base font-medium text-slate-800 dark:text-slate-100">
+          {value}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+type HighlightItemProps = {
+  title: string;
+  description: string;
+};
+
+function HighlightItem({ title, description }: HighlightItemProps) {
+  return (
+    <div className="rounded-2xl border border-slate-200/60 bg-white/70 p-5 shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl dark:border-slate-700/60 dark:bg-slate-950/60">
+      <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+        {title}
+      </h4>
+      <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+type ConnectionCardProps = {
+  title: string;
+  description: string;
+  href: string;
+};
+
+function ConnectionCard({ title, description, href }: ConnectionCardProps) {
+  return (
+    <a
+      className="group flex flex-col gap-2 rounded-2xl border border-slate-200/60 bg-white/80 p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 dark:border-slate-700/60 dark:bg-slate-950/70"
+      href={href}
+    >
+      <div className="flex items-center justify-between">
+        <h4 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          {title}
+        </h4>
+        <span className="text-slate-400 transition-transform group-hover:translate-x-1 dark:text-slate-500">
+          →
+        </span>
+      </div>
+      <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+        {description}
+      </p>
+    </a>
   );
 }
 
@@ -96,21 +271,14 @@ function SelfImage() {
   const isLoading = !(hasLoaded && hasMinDurationElapsed);
 
   return (
-    <div
-      className="flex justify-center items-center rounded-[50%]"
-      style={{
-        width: "384px",
-        height: "384px",
-        position: "relative",
-      }}
-    >
+    <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center rounded-[50%]">
       <DotLottieReact
         src="/image-load.lottie"
         autoplay
         loop
         style={{
-          width: 384,
-          height: 384,
+          width: "100%",
+          height: "100%",
           opacity: isLoading ? 1 : 0,
           visibility: isLoading ? "visible" : "hidden",
           transition: "opacity 0.5s ease-out, visibility 0.5s ease-out",
@@ -129,7 +297,7 @@ function SelfImage() {
         placeholder="empty"
         style={{
           width: "100%",
-          height: "auto",
+          height: "100%",
           opacity: isLoading ? 0 : 1,
           transition: "opacity 1s ease-in-out",
         }}

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -6,12 +6,12 @@ export default function Page() {
 
 function CenterSection() {
   return (
-    <div className="relative isolate min-h-[calc(100vh-6rem)] overflow-hidden bg-gradient-to-br from-amber-50 via-orange-50 to-amber-100 dark:from-stone-950 dark:via-zinc-950 dark:to-stone-900">
+    <div className="relative isolate min-h-[calc(100vh-8rem)] overflow-hidden bg-gradient-to-br from-[#fff3e1] via-[#fde2bb] to-[#fdf3e6] pb-16 dark:from-[#1d140d] dark:via-[#21170e] dark:to-[#0c0a09]">
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center blur-3xl">
         <div className="h-48 w-[36rem] bg-gradient-to-r from-amber-300/60 via-orange-300/60 to-amber-200/60 opacity-40 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
       </div>
 
-      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-16 sm:px-10 lg:px-16">
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 pt-16 pb-32 sm:px-10 lg:px-16">
         <section className="grid gap-10 rounded-3xl border border-amber-200/60 bg-amber-50/80 p-10 shadow-2xl backdrop-blur-xl transition-colors dark:border-stone-700/60 dark:bg-stone-900/70 dark:shadow-black/30 max-lg:p-8 lg:grid-cols-[1.1fr,0.9fr]">
           <div className="flex flex-col gap-6 text-stone-900 dark:text-amber-100">
             <div className="flex flex-wrap items-center gap-3 text-stone-600 dark:text-amber-200/80">

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -23,27 +23,37 @@ function CenterSection() {
               </span>
             </div>
             <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
-              Programmer, tinkerer, relentless explorer of ideas.
+              Hi, I’m Kyle.
             </h1>
             <p className="text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
-              I&#39;m a full-stack engineer who finds joy in building thoughtful
-              experiences and experimenting with new technologies. When I&#39;m
-              not writing code you can probably find me digging through obscure
-              electronic records, assembling hardware, or chasing down a new
-              hobby just to see how it works.
+              I’m a full-stack engineer from Newport News, Virginia. I spend my time writing code, 
+              building small form-factor PCs, designing parts in CAD, 3D printing, running a homelab, 
+              and making electronic music.
             </p>
             <div className="grid gap-6 sm:grid-cols-2">
               <InfoCard
-                title="Crafting &amp; Shipping"
-                description="From interactive web apps to physical prototypes, I love taking an idea from sketch to reality."
+                title="Building things"
+                description="Hardware projects, CAD designs, and 3D prints."
                 accent="from-amber-400/40 via-orange-300/40 to-transparent"
                 emoji="🛠️"
               />
               <InfoCard
-                title="Always Learning"
-                description="Recent dives include edge runtimes, creative coding, and modular synthesis—there&#39;s always a new rabbit hole."
+                title="Running systems"
+                description="Homelab servers, self-hosted tools, and experiments."
                 accent="from-amber-500/35 via-yellow-200/35 to-transparent"
-                emoji="🧠"
+                emoji="🖥️"
+              />
+              <InfoCard
+                title="Customizing setups"
+                description="Linux ricing, workflow tweaks, and configs."
+                accent="from-amber-400/40 via-orange-300/40 to-transparent"
+                emoji="💻"
+              />
+              <InfoCard
+                title="Making sound"
+                description="Electronic music, synths, and production experiments."
+                accent="from-amber-500/35 via-yellow-200/35 to-transparent"
+                emoji="🎶"
               />
             </div>
           </div>
@@ -55,10 +65,10 @@ function CenterSection() {
               </div>
             </div>
             <ul className="grid gap-3 text-sm text-stone-700 dark:text-amber-100/80">
-              <QuickFact label="Based in" value="Austin, TX" />
-              <QuickFact label="Currently exploring" value="AI-assisted tooling &amp; creative coding" />
-              <QuickFact label="Favorite mediums" value="TypeScript, React, analog synths" />
-              <QuickFact label="What I&#39;m building next" value="An experimental projects showcase" />
+              <QuickFact label="Location" value="Newport News, Virginia" />
+              <QuickFact label="Current focus" value="3D printing, CAD design, and homelab work" />
+              <QuickFact label="Projects" value="PC builds, car parts, self-hosted tools" />
+              <QuickFact label="Next up" value="More experiments across hardware and software" />
             </ul>
           </div>
         </section>
@@ -69,19 +79,14 @@ function CenterSection() {
               What drives me
             </h2>
             <p className="text-lg leading-relaxed">
-              I enjoy building and experimenting—whether it&#39;s hardware,
-              software, or a side project that piques my interest. I&#39;m
-              constantly learning and expanding my skill set, always focused on
-              creating something meaningful and well-crafted.
+              I work across software and hardware: writing code, putting together PCs, 
+              designing in CAD, and running a homelab.
             </p>
             <p className="leading-relaxed">
-              This site is still a work in progress. I&#39;m assembling a
-              showcase that blends personal experiments with production-ready
-              work, along with behind-the-scenes write-ups and process notes.
+              This site is a place to post projects and notes as I go.
             </p>
             <p className="leading-relaxed">
-              Content will continue to evolve here, so check back for updates
-              as new projects, articles, and collaborations roll out.
+              More will show up here over time.
             </p>
           </div>
 
@@ -91,16 +96,20 @@ function CenterSection() {
             </h3>
             <div className="grid gap-4">
               <HighlightItem
-                title="Hands-on with edge runtimes"
-                description="Deploying real-time features with minimal latency using Next.js App Router."
+                title="Printed a new car part"
+                description="Tested a fresh CAD design on the car."
               />
               <HighlightItem
-                title="Designing creative coding sketches"
-                description="Experimenting with shader-based visuals and generative art installations."
+                title="Tweaked the homelab"
+                description="Added a new service and cleaned up configs."
               />
               <HighlightItem
-                title="Building a modular synth rig"
-                description="Combining code, hardware, and music theory into a tactile sound playground."
+                title="Riced a Linux setup"
+                description="Customized the desktop and workflows."
+              />
+              <HighlightItem
+                title="Made some music"
+                description="Recorded and played around with new tracks."
               />
             </div>
           </div>
@@ -110,14 +119,10 @@ function CenterSection() {
           <div className="space-y-6 text-stone-800 dark:text-amber-100">
             <h2 className="text-2xl font-semibold">Connect with me</h2>
             <p>
-              If you&#39;d like to see more of my work or collaborate on an
-              idea, I&#39;d love to chat. You can reach out via GitHub,
-              LinkedIn, or email—links are in the contact section. I&#39;m
-              always open to conversations.
+              My work is on GitHub, LinkedIn, and here. Use the links below to check it out.
             </p>
             <p className="text-sm text-stone-600 dark:text-amber-200/70">
-              Bonus: mention your favorite synth, playlist, or side project
-              when you say hi.
+              Software, hardware, and side projects all get posted over time.
             </p>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -133,12 +138,12 @@ function CenterSection() {
             />
             <ConnectionCard
               title="Email"
-              description="Drop me a line for projects, jam sessions, or just to say hi."
+              description="For projects or collaboration."
               href="mailto:hello@example.com"
             />
             <ConnectionCard
               title="Now page"
-              description="A living snapshot of what I&#39;m learning and building."
+              description="A snapshot of what I’m working on."
               href="#"
             />
           </div>

--- a/src/app/about-me/self-image.tsx
+++ b/src/app/about-me/self-image.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Image from "next/image";
+import dynamic from "next/dynamic";
+import { useEffect, useRef, useState } from "react";
+
+const DotLottie = dynamic(
+  () =>
+    import("@lottiefiles/dotlottie-react").then((mod) => mod.DotLottieReact),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full animate-pulse rounded-full bg-gradient-to-br from-amber-200 via-orange-200 to-amber-100 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
+    ),
+  }
+) as typeof import("@lottiefiles/dotlottie-react").DotLottieReact;
+
+export default function SelfImage() {
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [hasMinDurationElapsed, setHasMinDurationElapsed] = useState(false);
+  const minDuration = 300;
+  const imageRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (imageRef.current && imageRef.current.complete) {
+      setHasLoaded(true);
+      setHasMinDurationElapsed(true);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setHasMinDurationElapsed(true);
+    }, minDuration);
+
+    return () => clearTimeout(timer);
+  }, [minDuration]);
+
+  const handleImageLoad = () => {
+    setHasLoaded(true);
+  };
+
+  const isLoading = !(hasLoaded && hasMinDurationElapsed);
+
+  return (
+    <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center rounded-[50%]">
+      <DotLottie
+        src="/image-load.lottie"
+        autoplay
+        loop
+        style={{
+          width: "100%",
+          height: "100%",
+          opacity: isLoading ? 1 : 0,
+          visibility: isLoading ? "visible" : "hidden",
+          transition: "opacity 0.5s ease-out, visibility 0.5s ease-out",
+          position: "absolute",
+          inset: 0,
+          pointerEvents: "none",
+        }}
+      />
+      <Image
+        ref={imageRef}
+        src="/me.jpg"
+        alt="A picture of me"
+        sizes="100vw"
+        width={384}
+        height={384}
+        placeholder="empty"
+        style={{
+          width: "100%",
+          height: "100%",
+          opacity: isLoading ? 0 : 1,
+          transition: "opacity 1s ease-in-out",
+        }}
+        className="rounded-[50%] shadow-md"
+        onLoad={handleImageLoad}
+      />
+    </div>
+  );
+}

--- a/src/app/contact_info/contact-info.tsx
+++ b/src/app/contact_info/contact-info.tsx
@@ -8,14 +8,11 @@ export default function DisplayContactInfoModal() {
   return (
     <>
       <button
-        className="font-medium px-3 py-2 text-slate-700 dark:text-slate-300 rounded-md"
+        className="rounded-md px-3 py-2 font-medium text-amber-700 transition-colors hover:text-amber-800 dark:text-amber-200 dark:hover:text-amber-100"
         onClick={() => isOpen(!open)}
       >
         <span
-          className="flex relative before:content-[''] before:absolute before:block before:w-full before:h-[2px] 
-              before:-bottom-1.5 before:left-0 before:bg-slate-700 dark:before:bg-slate-300
-              before:hover:scale-x-100 before:scale-x-0 before:origin-top-left
-              before:transition before:ease-in-out before:duration-300"
+          className="relative flex before:absolute before:left-0 before:-bottom-1.5 before:block before:h-[2px] before:w-full before:origin-top-left before:scale-x-0 before:bg-amber-600 before:transition before:duration-300 before:ease-in-out hover:before:scale-x-100 dark:before:bg-amber-300"
         >
           Contact Info
         </span>
@@ -45,18 +42,18 @@ export default function DisplayContactInfoModal() {
                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
-                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white dark:bg-slate-600 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-                  <div className="bg-white dark:bg-slate-600 px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
+                <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-amber-50/95 text-left shadow-xl transition-all dark:bg-stone-900/90 sm:my-8 sm:w-full sm:max-w-lg">
+                  <div className="px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
                     <div className="sm:flex-col sm:items-start">
                       <div className="mt-3 my-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
                         <Dialog.Title
                           as="h3"
-                          className="text-base font-semibold leading-6 text-gray-900 dark:text-slate-300"
+                          className="text-base font-semibold leading-6 text-amber-900 dark:text-amber-200"
                         >
                           Email
                         </Dialog.Title>
                         <div className="mt-0">
-                          <p className="text-sm text-blue-500 hover:text-blue-900">
+                          <p className="text-sm font-medium text-amber-700 transition-colors hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
                             <a href="mailto:kylearmstrong96@outlook.com">
                               kylearmstrong96@outlook.com
                             </a>
@@ -66,12 +63,12 @@ export default function DisplayContactInfoModal() {
                       <div className="mt-3 my-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
                         <Dialog.Title
                           as="h3"
-                          className="text-base font-semibold leading-6 text-gray-900 dark:text-slate-300"
+                          className="text-base font-semibold leading-6 text-amber-900 dark:text-amber-200"
                         >
                           Github
                         </Dialog.Title>
                         <div className="mt-0">
-                          <p className="text-sm text-blue-500 hover:text-blue-900">
+                          <p className="text-sm font-medium text-amber-700 transition-colors hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
                             <a
                               href="https://github.com/robarmstrong96"
                               target="_blank"
@@ -85,12 +82,12 @@ export default function DisplayContactInfoModal() {
                       <div className="mt-3 my-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
                         <Dialog.Title
                           as="h3"
-                          className="text-base font-semibold leading-6 text-gray-900 dark:text-slate-300"
+                          className="text-base font-semibold leading-6 text-amber-900 dark:text-amber-200"
                         >
                           LinkedIn
                         </Dialog.Title>
                         <div className="mt-0">
-                          <p className="text-sm text-blue-500 hover:text-blue-900">
+                          <p className="text-sm font-medium text-amber-700 transition-colors hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
                             <a
                               href="https://www.linkedin.com/in/robert-kyle-armstrong/"
                               target="_blank"

--- a/src/app/footer/footer.tsx
+++ b/src/app/footer/footer.tsx
@@ -6,7 +6,7 @@ import DisplayContactInfoModal from "../contact_info/contact-info";
 
 export function Footer() {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 m-auto bg-white shadow-lg dark:bg-slate-900">
+    <div className="fixed inset-x-0 bottom-0 z-50 m-auto border-t border-amber-200/60 bg-amber-100/90 backdrop-blur-xl shadow-lg dark:border-stone-800/70 dark:bg-stone-950/85">
       <ListPages />
     </div>
   );
@@ -36,12 +36,12 @@ function PageButton({ route }: { route: Route }) {
   const router = useRouter();
   return (
     <button
-      className="font-medium px-3 py-2 text-slate-700 dark:text-slate-300 rounded-md"
+      className="rounded-md px-3 py-2 font-medium text-amber-800 transition-colors hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100"
       onClick={() => router.push(route.routePath!)}
     >
       <span
-        className="relative before:content-[''] before:absolute before:block before:w-full before:h-[2px] 
-              before:-bottom-1.5 before:left-0 before:bg-slate-700 dark:before:bg-slate-300
+        className="relative before:content-[''] before:absolute before:block before:w-full before:h-[2px]
+              before:-bottom-1.5 before:left-0 before:bg-amber-700 dark:before:bg-amber-300
               before:hover:scale-x-100 before:scale-x-0 before:origin-top-left
               before:transition before:ease-in-out before:duration-300"
       >

--- a/src/app/footer/footer.tsx
+++ b/src/app/footer/footer.tsx
@@ -6,29 +6,17 @@ import DisplayContactInfoModal from "../contact_info/contact-info";
 
 export function Footer() {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-50 m-auto border-t border-amber-200/60 bg-amber-100/90 backdrop-blur-xl shadow-lg dark:border-stone-800/70 dark:bg-stone-950/85">
-      <ListPages />
-    </div>
-  );
-}
-
-function ListPages() {
-  return (
-    <div className="flex justify-center space-x-5 py-1 ">
-      <div>
+    <footer className="fixed inset-x-0 bottom-0 z-50 h-20 border-t border-amber-200/60 bg-amber-100/90 backdrop-blur-xl shadow-lg dark:border-stone-800/70 dark:bg-stone-950/85">
+      <nav className="mx-auto flex h-full w-full max-w-5xl items-center justify-center gap-6 px-6">
         <PageButton
           route={routes.find((i) => i.routeEnum == SelectedPage.ABOUTME)!}
         />
-      </div>
-      <div>
         <PageButton
           route={routes.find((i) => i.routeEnum == SelectedPage.PROJECTS)!}
         />
-      </div>
-      <div>
         <DisplayContactInfoModal />
-      </div>
-    </div>
+      </nav>
+    </footer>
   );
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,13 +53,21 @@
 html,
 body {
   min-height: 100%;
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-size: cover;
-  background-position: center;
+  background-color: rgb(var(--background-base));
 }
 
 body {
   color: rgb(var(--foreground-rgb));
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,12 @@
   --foreground-rgb: 30 24 20;
   --background-base: 255 245 232;
   --background-accent: 255 236 214;
+  --app-surface: radial-gradient(
+    circle at top,
+    rgb(var(--background-accent) / 0.35) 0%,
+    rgb(var(--background-base) / 0.7) 50%,
+    rgb(var(--background-base)) 100%
+  );
 }
 
 @media (prefers-color-scheme: dark) {
@@ -19,19 +25,13 @@
 html,
 body {
   min-height: 100%;
-}
-
-html {
-  background: radial-gradient(
-      circle at top,
-      rgb(var(--background-accent) / 0.35) 0%,
-      rgb(var(--background-base) / 0.7) 50%,
-      rgb(var(--background-base)) 100%
-    )
-    rgb(var(--background-base));
+  background-color: rgb(var(--background-base)) !important;
+  background-image: var(--app-surface) !important;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: inherit;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,14 +86,23 @@ body {
 
 html {
   background-color: rgb(var(--background-base));
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-size: 260% 260%;
-  background-position: center;
-  background-attachment: fixed;
 }
 
 body {
+  position: relative;
   color: rgb(var(--foreground-rgb));
   background-color: transparent;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -30vh -20vw;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-size: 240% 240%;
+  background-position: center;
+  will-change: transform;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,25 +3,25 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 220, 219, 214;
-  --background-end-rgb: 220, 219, 214;
+  --foreground-rgb: 30 24 20;
+  --background-base: 255 245 232;
+  --background-accent: 255 236 214;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 0, 0, 0;
-    --background-start-rgb: 55 65 81;
-    --background-end-rgb: 55 65 81;
+    --foreground-rgb: 250 240 225;
+    --background-base: 19 14 11;
+    --background-accent: 28 20 16;
   }
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
+  background: radial-gradient(
+      circle at top,
+      rgb(var(--background-accent)) 0%,
+      rgb(var(--background-base)) 55%
     )
-    rgb(var(--background-start-rgb));
+    rgb(var(--background-base));
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,23 +86,14 @@ body {
 
 html {
   background-color: rgb(var(--background-base));
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-size: 260% 260%;
+  background-position: center;
+  background-attachment: fixed;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
   background-color: transparent;
-  position: relative;
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: -60vh -40vw;
-  z-index: -1;
-  pointer-events: none;
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-size: 260% 260%;
-  background-position: center;
-  transform: translateZ(0);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,29 +4,37 @@
 
 :root {
   --foreground-rgb: 30 24 20;
-  --background-base: 255 245 232;
-  --background-accent: 255 236 214;
+  --background-base: 253 243 230;
+  --background-accent: 250 232 204;
+  --background-glow: 255 216 173;
   --app-surface: radial-gradient(
-    circle at top,
-    rgb(var(--background-accent) / 0.35) 0%,
-    rgb(var(--background-base) / 0.7) 50%,
+    circle at 18% 18%,
+    rgb(var(--background-glow)) 0%,
+    rgb(var(--background-accent)) 48%,
     rgb(var(--background-base)) 100%
   );
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 250 240 225;
-    --background-base: 19 14 11;
-    --background-accent: 28 20 16;
+    --foreground-rgb: 248 240 228;
+    --background-base: 12 10 9;
+    --background-accent: 18 15 13;
+    --background-glow: 68 52 36;
+    --app-surface: radial-gradient(
+      circle at 22% 22%,
+      rgb(var(--background-glow)) 0%,
+      rgb(var(--background-accent)) 55%,
+      rgb(var(--background-base)) 100%
+    );
   }
 }
 
 html,
 body {
   min-height: 100%;
-  background-color: rgb(var(--background-base)) !important;
-  background-image: var(--app-surface) !important;
+  background: var(--app-surface);
+  background-color: rgb(var(--background-base));
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-size: cover;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,23 +86,14 @@ body {
 
 html {
   background-color: rgb(var(--background-base));
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-size: 220% 220%;
+  background-position: center top;
+  background-attachment: fixed;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  position: relative;
   background-color: transparent;
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: -20vh -20vw;
-  z-index: -1;
-  pointer-events: none;
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: 160% 160%;
-  transform: translateZ(0);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,11 +8,21 @@
   --background-accent: 250 232 204;
   --background-glow: 255 216 173;
   --app-surface: radial-gradient(
-    circle at 18% 18%,
-    rgb(var(--background-glow)) 0%,
-    rgb(var(--background-accent)) 48%,
-    rgb(var(--background-base)) 100%
-  );
+      circle at 16% 20%,
+      rgba(255, 214, 170, 0.85) 0%,
+      rgba(255, 214, 170, 0) 46%
+    ),
+    radial-gradient(
+      circle at 82% 18%,
+      rgba(255, 190, 150, 0.6) 0%,
+      rgba(255, 190, 150, 0) 40%
+    ),
+    radial-gradient(
+      circle at 50% 82%,
+      rgba(255, 228, 189, 0.55) 0%,
+      rgba(255, 228, 189, 0) 55%
+    ),
+    linear-gradient(145deg, #fef7ec 0%, #fde8c8 48%, #f8d29c 100%);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,22 +32,32 @@
     --background-accent: 18 15 13;
     --background-glow: 68 52 36;
     --app-surface: radial-gradient(
-      circle at 22% 22%,
-      rgb(var(--background-glow)) 0%,
-      rgb(var(--background-accent)) 55%,
-      rgb(var(--background-base)) 100%
-    );
+        circle at 18% 20%,
+        rgba(155, 96, 36, 0.35) 0%,
+        rgba(155, 96, 36, 0) 45%
+      ),
+      radial-gradient(
+        circle at 78% 16%,
+        rgba(210, 132, 54, 0.32) 0%,
+        rgba(210, 132, 54, 0) 42%
+      ),
+      radial-gradient(
+        circle at 48% 82%,
+        rgba(92, 58, 30, 0.4) 0%,
+        rgba(92, 58, 30, 0) 55%
+      ),
+      linear-gradient(160deg, #0f0b08 0%, #1a130d 46%, #23170f 100%);
   }
 }
 
 html,
 body {
   min-height: 100%;
-  background: var(--app-surface);
-  background-color: rgb(var(--background-base));
+  background-image: var(--app-surface);
   background-repeat: no-repeat;
   background-attachment: fixed;
   background-size: cover;
+  background-position: center;
 }
 
 body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,11 @@
   }
 }
 
+html,
+body {
+  background-color: rgb(var(--background-base));
+}
+
 body {
   color: rgb(var(--foreground-rgb));
   background: radial-gradient(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,7 +22,21 @@
       rgba(255, 228, 189, 0.55) 0%,
       rgba(255, 228, 189, 0) 55%
     ),
-    linear-gradient(145deg, #fef7ec 0%, #fde8c8 48%, #f8d29c 100%);
+    radial-gradient(
+      circle at 50% 45%,
+      rgba(255, 214, 170, 0.35) 0%,
+      rgba(255, 214, 170, 0.05) 42%,
+      rgba(var(--background-base) / 0.65) 72%,
+      rgba(var(--background-base) / 1) 100%
+    ),
+    linear-gradient(
+      150deg,
+      rgba(255, 244, 220, 0.85) 0%,
+      rgba(255, 227, 188, 0.65) 40%,
+      rgba(255, 211, 158, 0.45) 58%,
+      rgba(var(--background-base) / 0.96) 78%,
+      rgba(var(--background-base) / 1) 100%
+    );
 }
 
 @media (prefers-color-scheme: dark) {
@@ -46,7 +60,21 @@
         rgba(92, 58, 30, 0.4) 0%,
         rgba(92, 58, 30, 0) 55%
       ),
-      linear-gradient(160deg, #0f0b08 0%, #1a130d 46%, #23170f 100%);
+      radial-gradient(
+        circle at 52% 46%,
+        rgba(196, 126, 62, 0.24) 0%,
+        rgba(196, 126, 62, 0.06) 40%,
+        rgba(var(--background-base) / 0.7) 70%,
+        rgba(var(--background-base) / 1) 100%
+      ),
+      linear-gradient(
+        160deg,
+        rgba(26, 18, 13, 0.95) 0%,
+        rgba(28, 20, 14, 0.85) 35%,
+        rgba(35, 24, 16, 0.7) 58%,
+        rgba(var(--background-base) / 0.85) 78%,
+        rgba(var(--background-base) / 1) 100%
+      );
   }
 }
 
@@ -68,6 +96,6 @@ body::before {
   pointer-events: none;
   background-image: var(--app-surface);
   background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
+  background-size: 130% 130%;
+  background-position: center top;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,9 +42,9 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 248 240 228;
-    --background-base: 12 10 9;
-    --background-accent: 18 15 13;
-    --background-glow: 68 52 36;
+    --background-base: 34 25 18;
+    --background-accent: 44 32 24;
+    --background-glow: 96 64 40;
     --app-surface: radial-gradient(
         circle at 18% 20%,
         rgba(155, 96, 36, 0.35) 0%,
@@ -81,21 +81,15 @@
 html,
 body {
   min-height: 100%;
+  min-height: 100vh;
   background-color: rgb(var(--background-base));
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 180% 180%;
+  background-attachment: fixed;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-size: 130% 130%;
-  background-position: center top;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,14 +82,27 @@ html,
 body {
   min-height: 100%;
   min-height: 100vh;
+}
+
+html {
   background-color: rgb(var(--background-base));
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: 180% 180%;
-  background-attachment: fixed;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
+  position: relative;
+  background-color: transparent;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -20vh -20vw;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 160% 160%;
+  transform: translateZ(0);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,15 +18,20 @@
 
 html,
 body {
-  background-color: rgb(var(--background-base));
+  min-height: 100%;
+}
+
+html {
+  background: radial-gradient(
+      circle at top,
+      rgb(var(--background-accent) / 0.35) 0%,
+      rgb(var(--background-base) / 0.7) 50%,
+      rgb(var(--background-base)) 100%
+    )
+    rgb(var(--background-base));
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: radial-gradient(
-      circle at top,
-      rgb(var(--background-accent)) 0%,
-      rgb(var(--background-base)) 55%
-    )
-    rgb(var(--background-base));
+  background: inherit;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,14 +86,23 @@ body {
 
 html {
   background-color: rgb(var(--background-base));
-  background-image: var(--app-surface);
-  background-repeat: no-repeat;
-  background-size: 220% 220%;
-  background-position: center top;
-  background-attachment: fixed;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
   background-color: transparent;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: -60vh -40vw;
+  z-index: -1;
+  pointer-events: none;
+  background-image: var(--app-surface);
+  background-repeat: no-repeat;
+  background-size: 260% 260%;
+  background-position: center;
+  transform: translateZ(0);
 }

--- a/src/app/header/header.tsx
+++ b/src/app/header/header.tsx
@@ -2,8 +2,8 @@ import { ThemeSwitchHandler } from "../theme_switch/theme_switch";
 
 export function Header() {
   return (
-    <div className="fixed inset-x-0 top-0 z-50 min-w-full bg-neutral-50 shadow-md dark:bg-gray-900">
-      <div className="h-32 py-8 grid grid-cols-1">
+    <div className="fixed inset-x-0 top-0 z-50 min-w-full border-b border-amber-200/60 bg-amber-50/90 backdrop-blur-xl shadow-md dark:border-stone-800/70 dark:bg-stone-950/85">
+      <div className="grid h-32 grid-cols-1 py-8">
         <div className="flex justify-center">
           <Title />
         </div>
@@ -15,7 +15,7 @@ export function Header() {
 function Title() {
   return (
     <div>
-      <h1 className="max-[384px]:text-4xl text-5xl dark:text-slate-300 font-bold antialiased">
+      <h1 className="text-5xl font-bold antialiased text-stone-900 max-[384px]:text-4xl dark:text-amber-100">
         Kyle Armstrong
       </h1>
       <SubTitle />
@@ -26,7 +26,7 @@ function Title() {
 function SubTitle() {
   return (
     <div>
-      <h6 className="max-[384px]:text-xs max-[274px]:hidden py-1 flex justify-center text-md text-gray-500 dark:text-slate-400">
+      <h6 className="flex justify-center py-1 text-md text-amber-700 max-[384px]:text-xs max-[274px]:hidden dark:text-amber-200/80">
         full-stack software engineer
       </h6>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} flex min-h-screen flex-col`}>
         <Header />
-        <main className="flex-1 pb-24 pt-32">
+        <main className="flex-1 pb-20 pt-32">
           <Providers>{children}</Providers>
         </main>
         <Footer />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,15 +1,57 @@
 export default function Page() {
-    return (
-        <>
-        <div className="py-8 flex justify-center">
-          <div className="max-w-7xl max-h-dvh">
-            <div className="p-5 mx-5 rounded-lg bg-white shadow-md dark:bg-slate-600">
-              <p className="text-pretty dark:text-slate-300">
-                Work in progress...
+  return (
+    <section className="relative isolate min-h-[calc(100vh-8rem)] overflow-hidden bg-gradient-to-br from-[#fff3e1] via-[#fde4c2] to-[#fef6ea] py-16 dark:from-[#1d140d] dark:via-[#23170e] dark:to-[#0f0a08]">
+      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center blur-3xl">
+        <div className="h-44 w-[34rem] bg-gradient-to-r from-amber-300/50 via-orange-200/50 to-amber-100/50 opacity-60 dark:from-amber-500/25 dark:via-orange-500/25 dark:to-amber-500/25" />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 sm:px-10 lg:px-16">
+        <header className="max-w-2xl">
+          <h1 className="text-4xl font-semibold text-stone-900 dark:text-amber-100">Projects</h1>
+          <p className="mt-4 text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
+            A curated selection of builds, experiments, and ongoing explorations. Full write-ups are coming soon&mdash;here&apos;s a sneak peek at what&apos;s taking shape.
+          </p>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <article className="group relative overflow-hidden rounded-3xl border border-amber-200/60 bg-amber-50/80 p-8 shadow-xl backdrop-blur-xl transition-transform hover:-translate-y-1 hover:shadow-2xl dark:border-stone-700/60 dark:bg-stone-950/70">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-amber-200/40 via-orange-200/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            <div className="relative flex h-full flex-col gap-4 text-stone-800 dark:text-amber-100">
+              <span className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-amber-200/70">In Progress</span>
+              <h2 className="text-2xl font-semibold">Interactive Project Showcase</h2>
+              <p className="flex-1 text-base leading-relaxed text-stone-600 dark:text-amber-200/80">
+                Building a dynamic gallery to highlight development projects with rich visuals, behind-the-scenes notes, and live demos.
               </p>
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-300">Case study launching soon.</p>
             </div>
+          </article>
+
+          <article className="group relative overflow-hidden rounded-3xl border border-amber-200/60 bg-gradient-to-br from-amber-100 via-amber-50 to-orange-100 p-8 shadow-xl backdrop-blur-xl transition-transform hover:-translate-y-1 hover:shadow-2xl dark:border-stone-700/60 dark:bg-gradient-to-br dark:from-stone-950 dark:via-zinc-950 dark:to-stone-900">
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-amber-300/30 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            <div className="relative flex h-full flex-col gap-4 text-stone-800 dark:text-amber-100">
+              <span className="text-sm font-semibold uppercase tracking-wide text-stone-500 dark:text-amber-200/70">Concept</span>
+              <h2 className="text-2xl font-semibold">Experiential Audio Tools</h2>
+              <p className="flex-1 text-base leading-relaxed text-stone-600 dark:text-amber-200/80">
+                Designing browser-based instruments inspired by modular synthesis, blending real-time audio with expressive UI patterns.
+              </p>
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-300">Playable prototype in the works.</p>
+            </div>
+          </article>
+        </div>
+
+        <div className="relative overflow-hidden rounded-3xl border border-amber-200/60 bg-amber-100/70 p-8 shadow-xl backdrop-blur-xl transition-colors dark:border-stone-700/60 dark:bg-stone-900/70">
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-transparent via-amber-200/20 to-orange-200/20 dark:via-amber-500/10 dark:to-amber-500/10" />
+          <div className="relative flex flex-col gap-4 text-stone-800 dark:text-amber-100">
+            <h2 className="text-2xl font-semibold">What&apos;s next</h2>
+            <p className="text-base leading-relaxed text-stone-600 dark:text-amber-200/80">
+              I&apos;m refining this space to feature process notes, interactive prototypes, and shipping-ready apps. Expect deeper dives into design systems, performance tooling, and creative coding experiments.
+            </p>
+            <p className="text-sm text-stone-500 dark:text-amber-200/70">
+              Have a project in mind? Let&apos;s collaborate&mdash;reach out through the contact links below.
+            </p>
           </div>
         </div>
-      </>
-    )
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- restyle the about page with layered gradients, larger grid layout, and richer typography
- add reusable card components for highlights, quick facts, and connection links to fill the page with more content
- update the self portrait loader to scale responsively within the new layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d99543212c832cbde6414f19b6c706