### PR TITLE
Update self portrait styling and loading skeleton

### DIFF
--- a/src/app/about-me/self-image.tsx
+++ b/src/app/about-me/self-image.tsx
@@ -1,19 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import dynamic from "next/dynamic";
 import { useEffect, useRef, useState } from "react";
-
-const DotLottie = dynamic(
-  () =>
-    import("@lottiefiles/dotlottie-react").then((mod) => mod.DotLottieReact),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="h-full w-full animate-pulse rounded-full bg-gradient-to-br from-amber-200 via-orange-200 to-amber-100 dark:from-amber-500/30 dark:via-orange-500/30 dark:to-amber-500/30" />
-    ),
-  }
-) as typeof import("@lottiefiles/dotlottie-react").DotLottieReact;
 
 export default function SelfImage() {
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -42,20 +30,14 @@ export default function SelfImage() {
   const isLoading = !(hasLoaded && hasMinDurationElapsed);
 
   return (
-    <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center rounded-[50%]">
-      <DotLottie
-        src="/image-load.lottie"
-        autoplay
-        loop
+    <div className="relative flex aspect-square w-full max-w-[18rem] items-center justify-center overflow-hidden rounded-3xl">
+      <div
+        aria-hidden="true"
+        className="skeleton-avatar"
         style={{
-          width: "100%",
-          height: "100%",
           opacity: isLoading ? 1 : 0,
           visibility: isLoading ? "visible" : "hidden",
-          transition: "opacity 0.5s ease-out, visibility 0.5s ease-out",
-          position: "absolute",
-          inset: 0,
-          pointerEvents: "none",
+          transition: "opacity 0.4s ease-out, visibility 0.4s ease-out",
         }}
       />
       <Image
@@ -72,7 +54,7 @@ export default function SelfImage() {
           opacity: isLoading ? 0 : 1,
           transition: "opacity 1s ease-in-out",
         }}
-        className="rounded-[50%] shadow-md"
+        className="rounded-3xl object-cover shadow-md"
         onLoad={handleImageLoad}
       />
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,8 @@
   --background-base: 253 243 230;
   --background-accent: 250 232 204;
   --background-glow: 255 216 173;
+  --skeleton-base: 244 235 225;
+  --skeleton-highlight: 255 255 255;
   --app-surface: radial-gradient(
       circle at 16% 20%,
       rgba(255, 214, 170, 0.85) 0%,
@@ -45,6 +47,8 @@
     --background-base: 34 25 18;
     --background-accent: 44 32 24;
     --background-glow: 96 64 40;
+    --skeleton-base: 60 44 34;
+    --skeleton-highlight: 120 92 68;
     --app-surface: radial-gradient(
         circle at 18% 20%,
         rgba(155, 96, 36, 0.35) 0%,
@@ -107,4 +111,36 @@ body::before {
   background-size: 240% 240%;
   background-position: center;
   will-change: transform;
+}
+
+.skeleton-avatar {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
+  background-color: rgb(var(--skeleton-base));
+}
+
+.skeleton-avatar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    rgba(var(--skeleton-base) / 0),
+    rgba(var(--skeleton-highlight) / 0.55),
+    rgba(var(--skeleton-base) / 0)
+  );
+  animation: skeleton-shimmer 1.6s infinite;
+  will-change: transform;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }


### PR DESCRIPTION
## Summary
- restyle the about me portrait to render as a rounded square with proper image cropping
- replace the lottie-based loader with a lightweight skeleton shimmer that adapts to light and dark themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9cf14b54c832c8910271e6d84a8bb