### PR TITLE
Fix project image assets and offline font usage

### DIFF
--- a/public/projects/cad-print.svg
+++ b/public/projects/cad-print.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Abstract 3D printer illustration</title>
+  <desc id="desc">Line art of a 3D printer frame with a print in progress.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff5e6" />
+      <stop offset="100%" stop-color="#fde6c8" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#ea580c" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="360" fill="url(#bg)" rx="24" ry="24" />
+  <g fill="none" stroke="#f97316" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+    <rect x="120" y="60" width="400" height="240" rx="24" ry="24" />
+    <rect x="180" y="120" width="280" height="160" rx="18" ry="18" />
+    <line x1="320" y1="60" x2="320" y2="24" />
+    <polyline points="200,120 200,90 440,90 440,120" />
+    <polyline points="220,280 220,300 420,300 420,280" />
+  </g>
+  <g fill="none" stroke="url(#accent)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M280 140h80l12 72-52 36-52-36z" />
+    <path d="M312 248v36" />
+    <path d="M328 248v36" />
+  </g>
+  <g fill="none" stroke="#fb923c" stroke-width="6" stroke-linecap="round" opacity="0.6">
+    <path d="M160 192h-24" />
+    <path d="M160 224h-24" />
+    <path d="M504 192h24" />
+    <path d="M504 224h24" />
+    <path d="M280 90V60" />
+    <path d="M360 90V60" />
+  </g>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,10 @@
 import "./globals.css";
 import "./background-animated.css"
 
-import { Inter } from "next/font/google";
 import { Header } from "./header/header";
 import { Footer } from "./footer/footer";
 import type { Metadata } from "next";
 import { Providers } from "./providers";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Kyle Armstrong",
@@ -21,7 +18,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} flex min-h-screen flex-col`}>
+      <body className="flex min-h-screen flex-col font-sans">
         <Header />
         <main className="flex-1 pb-20 pt-32">
           <Providers>{children}</Providers>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -4,6 +4,25 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 
+type ProjectImage = {
+  src: string;
+  alt: string;
+  caption?: string;
+};
+
+type Project = {
+  id: string;
+  status: string;
+  title: string;
+  summary: string;
+  focus: string;
+  tags: readonly string[];
+  metrics: readonly { value: string; label: string }[];
+  milestones: readonly { label: string; description: string }[];
+  sections: readonly { heading: string; body: readonly string[] }[];
+  image?: ProjectImage;
+};
+
 const projects = [
   {
     id: 'showcase',
@@ -158,9 +177,7 @@ const projects = [
       caption: 'Placeholder illustration until I add real print photos.',
     },
   },
-] as const;
-
-type Project = (typeof projects)[number];
+] satisfies readonly Project[];
 
 export default function Page() {
   const [expandedId, setExpandedId] = useState<string | null>(projects[0]?.id ?? null);


### PR DESCRIPTION
## Summary
- add an inline type definition for project data and ensure imagery is optional while providing a placeholder SVG for the CAD project
- switch the root layout to Tailwind's sans-serif stack so the build no longer depends on downloading Google Fonts

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e0ece4c4832cb749986ea095b0dc