### PR TITLE
Update contact links and add Now redirect

### DIFF
--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -131,22 +131,22 @@ function CenterSection() {
             <ConnectionCard
               title="Github"
               description="Code, experiments, and open-source contributions."
-              href="https://github.com"
+              href="https://github.com/robarmstrong96"
             />
             <ConnectionCard
               title="LinkedIn"
               description="Work history, collaboration ideas, and professional updates."
-              href="https://www.linkedin.com"
+              href="https://www.linkedin.com/in/robert-kyle-armstrong/"
             />
             <ConnectionCard
               title="Email"
               description="For projects or collaboration."
-              href="mailto:hello@example.com"
+              href="mailto:kylearmstrong96@outlook.com"
             />
             <ConnectionCard
-              title="Now page"
+              title="Projects"
               description="A snapshot of what I’m working on."
-              href="#"
+              href="/projects"
             />
           </div>
         </section>
@@ -227,10 +227,14 @@ type ConnectionCardProps = {
 };
 
 function ConnectionCard({ title, description, href }: ConnectionCardProps) {
+  const isExternalLink = href.startsWith("http");
+
   return (
     <a
       className="group flex flex-col gap-2 rounded-2xl border border-amber-200/60 bg-amber-50/80 p-6 text-left shadow-lg transition-transform hover:-translate-y-1 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 dark:border-stone-700/60 dark:bg-stone-950/70"
       href={href}
+      target={isExternalLink ? "_blank" : undefined}
+      rel={isExternalLink ? "noopener noreferrer" : undefined}
     >
       <div className="flex items-center justify-between">
         <h4 className="text-lg font-semibold text-stone-900 dark:text-amber-100">

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/projects");
+}


### PR DESCRIPTION
## Summary
- align the "Connect with me" cards with the email, GitHub, and LinkedIn links from the contact modal
- rename the Now card to Projects and ensure external cards open in a new tab
- add a /now route that redirects to the Projects page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9e8582cf0832ca3f8e2419b4f12e9