### PR TITLE
Fix grammar and improve milestone contrast

### DIFF
--- a/src/app/about-me/components/connect-section.tsx
+++ b/src/app/about-me/components/connect-section.tsx
@@ -5,7 +5,7 @@ import { ConnectionCard, type ConnectionCardProps } from "./connection-card";
 
 const connections: ConnectionCardProps[] = [
   {
-    title: "Github",
+    title: "GitHub",
     description: "Code, experiments, and open-source contributions.",
     href: "https://github.com/robarmstrong96",
   },

--- a/src/app/about-me/components/hero-section.tsx
+++ b/src/app/about-me/components/hero-section.tsx
@@ -61,8 +61,8 @@ export function HeroSection() {
           </div>
           <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">Hi, I’m Kyle.</h1>
           <p className="text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
-            I’m a software engineer from Hampton Roads area in Virginia. I spend my time writing code, building small form-factor PCs,
-            designing parts in CAD, 3D printing, running a homelab, making electronic music, and various other things.
+            I’m a software engineer from the Hampton Roads area in Virginia. I spend my time writing code, building small form-factor PCs,
+            designing parts in CAD, 3D printing, running a homelab, making electronic music, and exploring other hands-on projects.
           </p>
         </SkeletonReveal>
         <div className="grid gap-6 sm:grid-cols-2 lg:mt-auto lg:pt-4">

--- a/src/app/about-me/components/hero-section.tsx
+++ b/src/app/about-me/components/hero-section.tsx
@@ -61,7 +61,7 @@ export function HeroSection() {
           </div>
           <h1 className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">Hi, I’m Kyle.</h1>
           <p className="text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
-            I’m a software engineer from the Hampton Roads area in Virginia. I spend my time writing code, building small form-factor PCs,
+            I’m a software engineer from Hampton Roads, Virginia. I spend my time writing code, building small form-factor PCs,
             designing parts in CAD, 3D printing, running a homelab, making electronic music, and exploring other hands-on projects.
           </p>
         </SkeletonReveal>

--- a/src/app/about-me/components/passion-section.tsx
+++ b/src/app/about-me/components/passion-section.tsx
@@ -26,7 +26,7 @@ export function PassionSection() {
         <p className="text-lg leading-relaxed">
           I work across software and hardware: writing code, putting together PCs, designing in CAD, and running a homelab.
         </p>
-        <p className="leading-relaxed">This site is a place to post projects and other noteworthy things as I go.</p>
+        <p className="leading-relaxed">This site is where I post projects and other noteworthy things as I go.</p>
         <p className="leading-relaxed">More will show up here over time.</p>
       </SkeletonReveal>
 

--- a/src/app/contact_info/contact-info.tsx
+++ b/src/app/contact_info/contact-info.tsx
@@ -22,7 +22,7 @@ export default function DisplayContactInfoModal() {
         icon: "✉️",
       },
       {
-        label: "Github",
+        label: "GitHub",
         href: "https://github.com/robarmstrong96",
         display: "github.com/robarmstrong96",
         icon: "💻",

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -37,9 +37,9 @@ const projects = [
     status: 'Scaffolding',
     title: 'Project showcase (placeholder)',
     summary:
-      "You're looking at the *shell* for a future write‑up. This exists so you can see how entries will look and expand. Real content will land here once it exists.",
+      "You're looking at the *shell* for a future write‑up. It exists so you can see how entries will look and expand. Real content will land here once it exists.",
     focus:
-      'When there is an actual project, this block will explain the build, stack, and interesting problems solved — for now, it just proves the layout.',
+      'When an actual project exists, this block will explain the build, stack, and interesting problems solved — for now, it just proves the layout.',
     tags: ['Placeholder', 'Concept', 'Layout'],
     metrics: [
       { value: 'TBD', label: 'Launch target' },
@@ -200,7 +200,7 @@ export default function Page() {
           <p className="mt-4 text-lg leading-relaxed text-stone-700 dark:text-amber-200/80">
             This page is a working mock. It shows how project cards expand, where notes will live,
             and how metrics/milestones render. Lower expectations now; raise them later. When real
-            projects are ready, these placeholders get replaced.
+            projects are ready, these placeholders will be replaced.
           </p>
         </header>
 
@@ -330,7 +330,7 @@ export default function Page() {
                                 key={milestone.label}
                                 className="rounded-xl border border-amber-200/70 bg-amber-50/80 p-4 dark:border-stone-700/70 dark:bg-stone-800/60"
                               >
-                                <p className="text-xs font-semibold uppercase tracking-wide text-amber-700/80 dark:text-amber-200/80">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-stone-900 dark:text-amber-100">
                                   {milestone.label}
                                 </p>
                                 <p className="mt-1 text-sm leading-relaxed">{milestone.description}</p>
@@ -357,7 +357,7 @@ export default function Page() {
               projects finish. If you’re here early, congrats — you’re seeing the scaffolding.
             </p>
             <p className="text-sm text-stone-500 dark:text-amber-200/70">
-              Translated: lower expectations now, return later for the good stuff.
+              Translated: lower expectations now and return later for the good stuff.
             </p>
           </div>
         </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -244,7 +244,7 @@ export default function Page() {
                     {project.tags.map((tag) => (
                       <span
                         key={tag}
-                        className="rounded-full bg-amber-200/80 px-3 py-1 text-xs font-medium text-amber-800 transition selection:bg-amber-300 selection:text-stone-900 group-hover:bg-amber-200 dark:bg-stone-800/70 dark:text-amber-200 dark:selection:bg-amber-500 dark:selection:text-stone-950"
+                        className="rounded-full bg-amber-200/80 px-3 py-1 text-xs font-medium text-amber-800 transition-colors selection:bg-amber-300 selection:text-stone-900 group-hover:bg-amber-200 group-hover:text-amber-950 group-focus-within:bg-amber-200 group-focus-within:text-amber-950 dark:bg-stone-800/70 dark:text-amber-200 dark:selection:bg-amber-500 dark:selection:text-stone-950 dark:group-hover:bg-stone-800 dark:group-hover:text-amber-100 dark:group-focus-within:bg-stone-800 dark:group-focus-within:text-amber-100"
                       >
                         {tag}
                       </span>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -328,12 +328,14 @@ export default function Page() {
                             {project.milestones.map((milestone) => (
                               <li
                                 key={milestone.label}
-                                className="rounded-xl border border-amber-200/70 bg-amber-50/80 p-4 dark:border-stone-700/70 dark:bg-stone-800/60"
+                                className="group/milestone rounded-xl border border-amber-200/70 bg-amber-50/80 p-4 transition-colors duration-300 hover:bg-amber-200/80 focus-within:bg-amber-200/80 dark:border-stone-700/70 dark:bg-stone-800/60 dark:hover:bg-stone-800/80 dark:focus-within:bg-stone-800/80"
                               >
-                                <p className="text-xs font-semibold uppercase tracking-wide text-stone-900 dark:text-amber-100">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-stone-900 transition-colors group-hover/milestone:text-stone-950 dark:text-amber-100 dark:group-hover/milestone:text-amber-50">
                                   {milestone.label}
                                 </p>
-                                <p className="mt-1 text-sm leading-relaxed">{milestone.description}</p>
+                                <p className="mt-1 text-sm leading-relaxed text-stone-700 transition-colors group-hover/milestone:text-stone-900 dark:text-amber-200/80 dark:group-hover/milestone:text-amber-100">
+                                  {milestone.description}
+                                </p>
                               </li>
                             ))}
                           </ul>


### PR DESCRIPTION
## Summary
- correct grammar and capitalization across hero, passion, contact, and projects content
- adjust projects page copy to read more naturally and improve the milestone label text contrast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0c20edf90832c9363fe038a726d0b